### PR TITLE
Fix null-ref exception when there are Yummi coupons

### DIFF
--- a/Couper/Form1.cs
+++ b/Couper/Form1.cs
@@ -34,7 +34,7 @@ namespace Couper
         private Microsoft.Office.Interop.OneNote.Application _app;
 
         private const string TitleCode = "קוד שובר";
-        private const string TitleCode2 = "שובר לרכישה";
+        private const string TitleCode2 = "לרכישה";
         private const string TitleAmount = "סכום ההזמנה";
         private const string TitleAmount2 = "החיוב בסיבוס שלך";
         private const string TitleExpires = "תוקף";


### PR DESCRIPTION
TitleCode2 should be more general to support other coupons (not Shufersal) - Yummi uses 'קופון לרכישה' instead of 'שובר לרכישה'